### PR TITLE
Get runtime type of TMessage

### DIFF
--- a/src/core/RawMessageDispatcher.cs
+++ b/src/core/RawMessageDispatcher.cs
@@ -14,7 +14,7 @@ namespace CR.MessageDispatch.Core
 
         protected override bool TryGetMessageType(TMessage rawMessage, out Type type)
         {
-            type = typeof(TMessage);
+            type = rawMessage.GetType();
             return true;
         }
 


### PR DESCRIPTION
typeof(TMessage) returns compile time type which is usually 'object' and therefore Dispatch method can't find handlers for it later.
